### PR TITLE
Implement loom version of parking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
+      - run: cargo test --test loom --features loom
+        env:
+          RUSTFLAGS: --cfg loom
+          LOOM_MAX_PREEMPTIONS: 2
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ keywords = ["park", "notify", "thread", "wake", "condition"]
 categories = ["concurrency"]
 exclude = ["/.*"]
 
+# The `loom` feature, combined with the `loom` rustflag, enables a reimplementation
+# of `parking` using `loom`. This feature is perma-unstable and should not be used
+# in stable code.
 [target.'cfg(loom)'.dependencies.loom]
 version = "0.5"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ keywords = ["park", "notify", "thread", "wake", "condition"]
 categories = ["concurrency"]
 exclude = ["/.*"]
 
+[target.'cfg(loom)'.dependencies.loom]
+version = "0.5"
+optional = true
+
 [dev-dependencies]
 easy-parallel = "3.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,10 @@ use loom::sync;
 use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+#[cfg(not(all(loom, feature = "loom")))]
+use std::time::Instant;
 
 use sync::atomic::AtomicUsize;
 use sync::atomic::Ordering::SeqCst;
@@ -340,6 +343,7 @@ impl Inner {
 
                 #[cfg(loom)]
                 {
+                    let _ = timeout;
                     panic!("park_timeout is not supported under loom");
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
-#[cfg(not(loom))]
+#[cfg(not(all(loom, feature = "loom")))]
 use std::sync;
 
-#[cfg(loom)]
+#[cfg(all(loom, feature = "loom"))]
 use loom::sync;
 
 use std::cell::Cell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::time::{Duration, Instant};
 
-use sync::atomic::Ordering::SeqCst;
 use sync::atomic::AtomicUsize;
-use sync::{Arc, Mutex, Condvar};
+use sync::atomic::Ordering::SeqCst;
+use sync::{Arc, Condvar, Mutex};
 
 /// Creates a parker and an associated unparker.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,20 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
+#[cfg(not(loom))]
+use std::sync;
+
+#[cfg(loom)]
+use loom::sync;
+
 use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
-use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
+
+use sync::atomic::Ordering::SeqCst;
+use sync::atomic::AtomicUsize;
+use sync::{Arc, Mutex, Condvar};
 
 /// Creates a parker and an associated unparker.
 ///
@@ -119,6 +126,7 @@ impl Parker {
     /// // Wait for a notification, or time out after 500 ms.
     /// p.park_timeout(Duration::from_millis(500));
     /// ```
+    #[cfg(not(loom))]
     pub fn park_timeout(&self, duration: Duration) -> bool {
         self.unparker.inner.park(Some(duration))
     }
@@ -138,6 +146,7 @@ impl Parker {
     /// // Wait for a notification, or time out after 500 ms.
     /// p.park_deadline(Instant::now() + Duration::from_millis(500));
     /// ```
+    #[cfg(not(loom))]
     pub fn park_deadline(&self, instant: Instant) -> bool {
         self.unparker
             .inner
@@ -315,15 +324,23 @@ impl Inner {
                 }
             }
             Some(timeout) => {
-                // Wait with a timeout, and if we spuriously wake up or otherwise wake up from a
-                // notification we just want to unconditionally set `state` back to `EMPTY`, either
-                // consuming a notification or un-flagging ourselves as parked.
-                let (_m, _result) = self.cvar.wait_timeout(m, timeout).unwrap();
+                #[cfg(not(loom))]
+                {
+                    // Wait with a timeout, and if we spuriously wake up or otherwise wake up from a
+                    // notification we just want to unconditionally set `state` back to `EMPTY`, either
+                    // consuming a notification or un-flagging ourselves as parked.
+                    let (_m, _result) = self.cvar.wait_timeout(m, timeout).unwrap();
 
-                match self.state.swap(EMPTY, SeqCst) {
-                    NOTIFIED => true, // got a notification
-                    PARKED => false,  // no notification
-                    n => panic!("inconsistent park_timeout state: {}", n),
+                    match self.state.swap(EMPTY, SeqCst) {
+                        NOTIFIED => true, // got a notification
+                        PARKED => false,  // no notification
+                        n => panic!("inconsistent park_timeout state: {}", n),
+                    }
+                }
+
+                #[cfg(loom)]
+                {
+                    panic!("park_timeout is not supported under loom");
                 }
             }
         }

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,14 @@
+#![cfg(loom)]
+
+#[test]
+fn smoke() {
+    loom::model(|| {
+        let (p, u) = parking::pair();
+
+        loom::thread::spawn(move || {
+            p.park(); 
+        });
+
+        u.unpark();
+    });
+}

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -6,7 +6,7 @@ fn smoke() {
         let (p, u) = parking::pair();
 
         loom::thread::spawn(move || {
-            p.park(); 
+            p.park();
         });
 
         u.unpark();


### PR DESCRIPTION
In smol-rs/event-listener#30, I implemented my own version of `parking` using Loom primitives. @zseri [asked me to upstream it to this repository](https://github.com/smol-rs/event-listener/pull/30#discussion_r986122623). This PR adds a new "loom" feature that, when the Rust `--cfg loom` flag is enabled, reimplements `parking` using Loom primitives.

Since `loom` doesn't support timeouts there's not much that I can really do in terms of testing, so I just added a simple smoke test.