### PR TITLE
v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.2.1
+
+- Specify the reason for using `parking` in the docs. (#25)
+
 # Version 2.2.0
 
 - Implement `From<Unparker>` for `Waker`. This enables `Waker`s to be constructed from `Unparker`s without allocating. (#18)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "parking"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.2.0"
+version = "2.2.1"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "The Rust Project Developers",


### PR DESCRIPTION
- Specify the reason for using `parking` in the docs. (#25)
